### PR TITLE
Dev

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+LiCSBAS_lib/__pycache__

--- a/bin/LiCSBAS16_filt_ts.py
+++ b/bin/LiCSBAS16_filt_ts.py
@@ -376,7 +376,39 @@ def main(argv=None):
             if tide:
                 tide_org = cumh5['tide'][()]
             if iono:
-                iono_org = cumh5['iono'][()]    
+                iono_org = cumh5['iono'][()]
+                
+    
+    #%% drop the epochs if all NaN for cum, tide or iono
+    if sbovl:
+        # Identify epochs where correction grids are entirely NaN
+        bad = np.zeros(cum_org.shape[0], dtype=bool)
+
+        if tide:
+            tide_allnan = np.all(np.isnan(tide_org), axis=(1, 2))
+            bad |= tide_allnan
+
+        if iono:
+            iono_allnan = np.all(np.isnan(iono_org), axis=(1, 2))
+            bad |= iono_allnan
+
+        if np.any(bad):
+            bad_ix = np.where(bad)[0]
+            bad_dates = [imdates[i] for i in bad_ix]
+            print(f"WARNING: Dropping {bad.sum()} epochs with all-NaN tide/iono: {bad_dates}", flush=True)
+
+            keep = ~bad
+
+            # Drop from time series arrays
+            cum_org = cum_org[keep, :, :]
+            if tide:
+                tide_org = tide_org[keep, :, :]
+            if iono:
+                iono_org = iono_org[keep, :, :]
+
+            # Drop from date list
+            imdates = [d for d, k in zip(imdates, keep) if k]
+
     n_im, length, width = cum_org.shape
 
     #%% tide and iono removal for sboi before filtering
@@ -866,7 +898,7 @@ def main(argv=None):
     vel_tmp = np.zeros(n_pt_unnan, dtype=np.float32)*np.nan
 
     bool_nonan_pt = np.all(~np.isnan(cum_pt), axis=0)
-
+    breakpoint()
     ### First, calc vel point without nan
     print('  First, solving {0:6}/{1:6}th points with full cum...'.format(bool_nonan_pt.sum(), n_pt_unnan), flush=True)
     vconst_tmp[bool_nonan_pt], vel_tmp[bool_nonan_pt] = np.linalg.lstsq(G, cum_pt[:, bool_nonan_pt], rcond=None)[0]

--- a/bin/LiCSBAS16_filt_ts.py
+++ b/bin/LiCSBAS16_filt_ts.py
@@ -898,7 +898,7 @@ def main(argv=None):
     vel_tmp = np.zeros(n_pt_unnan, dtype=np.float32)*np.nan
 
     bool_nonan_pt = np.all(~np.isnan(cum_pt), axis=0)
-    breakpoint()
+    
     ### First, calc vel point without nan
     print('  First, solving {0:6}/{1:6}th points with full cum...'.format(bool_nonan_pt.sum(), n_pt_unnan), flush=True)
     vconst_tmp[bool_nonan_pt], vel_tmp[bool_nonan_pt] = np.linalg.lstsq(G, cum_pt[:, bool_nonan_pt], rcond=None)[0]

--- a/bin/LiCSBAS16_filt_ts.py
+++ b/bin/LiCSBAS16_filt_ts.py
@@ -379,35 +379,26 @@ def main(argv=None):
                 iono_org = cumh5['iono'][()]
                 
     
-    #%% drop the epochs if all NaN for cum, tide or iono
+    #%% If tide/iono are all-NaN for an epoch, set that correction epoch to 0 (skip correction), separately for each
     if sbovl:
-        # Identify epochs where correction grids are entirely NaN
-        bad = np.zeros(cum_org.shape[0], dtype=bool)
-
+        #tide
         if tide:
             tide_allnan = np.all(np.isnan(tide_org), axis=(1, 2))
-            bad |= tide_allnan
-
+            if np.any(tide_allnan):
+                bad_ix = np.where(tide_allnan)[0]
+                bad_dates = [imdates[i] for i in bad_ix]
+                print(f"WARNING: Tide is full-NaN for {len(bad_ix)} epochs. "
+                    f"Skipping tide (set to 0) on: {bad_dates}", flush=True)
+                tide_org[tide_allnan, :, :] = 0.0
+        #iono
         if iono:
             iono_allnan = np.all(np.isnan(iono_org), axis=(1, 2))
-            bad |= iono_allnan
-
-        if np.any(bad):
-            bad_ix = np.where(bad)[0]
-            bad_dates = [imdates[i] for i in bad_ix]
-            print(f"WARNING: Dropping {bad.sum()} epochs with all-NaN tide/iono: {bad_dates}", flush=True)
-
-            keep = ~bad
-
-            # Drop from time series arrays
-            cum_org = cum_org[keep, :, :]
-            if tide:
-                tide_org = tide_org[keep, :, :]
-            if iono:
-                iono_org = iono_org[keep, :, :]
-
-            # Drop from date list
-            imdates = [d for d, k in zip(imdates, keep) if k]
+            if np.any(iono_allnan):
+                bad_ix = np.where(iono_allnan)[0]
+                bad_dates = [imdates[i] for i in bad_ix]
+                print(f"WARNING: Iono is full-NaN for {len(bad_ix)} epochs. "
+                    f"Skipping iono (set to 0) on: {bad_dates}", flush=True)
+                iono_org[iono_allnan, :, :] = 0.0
 
     n_im, length, width = cum_org.shape
 
@@ -1024,7 +1015,10 @@ def main(argv=None):
     print('Output: {}\n'.format(os.path.relpath(cumffile)), flush=True)
 
     print('To plot the time-series:')
-    print('LiCSBAS_plot_ts.py -i {} &\n'.format(os.path.relpath(cumffile)))
+    if tide and iono:
+        print('LiCSBAS_plot_ts.py -i {} --corrections &\n'.format(os.path.relpath(cumffile)))
+    else:
+        print('LiCSBAS_plot_ts.py -i {} &\n'.format(os.path.relpath(cumffile)))
 
 
 #%%


### PR DESCRIPTION
Dear Milan, 

In LiCSBAS16:

If sboi flag is open;  full-NaN tide/iono epochs are no longer dropped. Instead, their correction grids are set to zero to preserve time-axis consistency and avoid NaN propagation during referencing? 